### PR TITLE
chore(deps): bump pycodestyle from 2.11.1 to 2.12.0 and flake8 from 7.0.0 to 7.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ iniconfig==2.0.0
 mccabe==0.7.0
 packaging==24.1
 pluggy==1.5.0
-pycodestyle==2.11.1
+pycodestyle==2.12.0
 pydantic==2.7.4
 pydantic_core
 pyflakes==3.2.0


### PR DESCRIPTION
- https://github.com/nanotaboada/python-samples-fastapi-restful/pull/122
- https://github.com/nanotaboada/python-samples-fastapi-restful/pull/123
