### PR TITLE
Fix Dockerfile setup issue (#330)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,11 @@
+
+
 # Ignore directories
 **/.github
 **/.vscode
+**/assets
+**/postman_collections
+**/tests
 
 # Ignore development and CI files
 **/.codacy.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,28 @@
+# Ignore directories
+**/.github
+**/.vscode
+
+# Ignore development and CI files
+**/.codacy.yml
+**/.coveragerc
+**/.flake8
+**/.git
+**/.gitignore
+**/.pylintrc
+**/codecov.yml
+**/LICENSE
+**/README.md
+**/requirements-lint.txt
+**/requirements-test.txt
+**/runtime.txt
+
+# Ignore local secrets/configuration
+**/.env
+**/env
+**/venv
+**/*.py[cod]
+**/__pycache__
+
+# Ignore OS/editor files
+**/.DS_Store
+**/Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Use an official Python runtime as a parent image
 FROM python:3.9-slim
 
+# Create a non-root user
+RUN useradd -m myuser
+
 # Set the working directory in the container
 WORKDIR /app
 
@@ -11,7 +14,11 @@ COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the current directory contents into the container at /app
+# Make sure to add a .dockerignore file to exclude sensitive files
 COPY . /app/
+
+# Change to the non-root user
+USER myuser
 
 # Expose the FastAPI app's port
 EXPOSE 9000

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use an official Python runtime as a parent image
+FROM python:3.9-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements.txt file into the container at /app
+COPY requirements.txt /app/
+
+# Install dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the current directory contents into the container at /app
+COPY . /app/
+
+# Expose the FastAPI app's port
+EXPOSE 9000
+
+# Run the FastAPI app using uvicorn when the container starts
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,10 @@ COPY requirements.txt /app/
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Copy the current directory contents into the container at /app
-# Make sure to add a .dockerignore file to exclude sensitive files
 COPY . /app/
+
+# Copy the SQLite database file into the container (even if /data is ignored)
+COPY ./data/players-sqlite3.db /app/data/players-sqlite3.db
 
 # Change to the non-root user
 USER myuser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # https://fastapi.tiangolo.com/#standard-dependencies
+uvicorn==0.18.3
 fastapi[standard]==0.115.12
 SQLAlchemy==2.0.40
 aiosqlite==0.21.0


### PR DESCRIPTION
Hey! 👋

I used a single-stage Dockerfile instead of the multi-stage one for now. The multi-stage version was causing issues because even though uvicorn was installed in the build stage, it wasn’t actually available in the final runtime image — which is why the container kept saying “uvicorn: command not found.”

Also added uvicorn==0.18.3 to requirements.txt since it’s needed to run the app.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/python-samples-fastapi-restful/337)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added containerization support for the application, enabling deployment using Docker.
- **Chores**
  - Introduced a `.dockerignore` file to optimize Docker builds and enhance security by excluding unnecessary files.
  - Added `uvicorn` as a dependency for running the FastAPI application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->