### PR TITLE
feat(docker): add Dockerfile to containerize FastAPI app (#330)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,42 @@
+# Stage 1: Base image to install dependencies
+FROM python:3.9-slim AS build
+
+WORKDIR /app
+
+# Install build dependencies if any are needed (optional)
+COPY requirements.txt .
+RUN pip install --upgrade pip && pip install --no-cache-dir -r requirements.txt
+
+# Copy only app files after installing dependencies
+COPY main.py ./
+COPY models/ ./models/
+COPY routes/ ./routes/
+COPY schemas/ ./schemas/
+COPY services/ ./services/
+COPY data/ ./data
+
+# Stage 2: Create a minimal runtime image
+FROM python:3.9-slim AS runtime
+
+# Create non-root user
+RUN useradd -m myuser
+
+WORKDIR /app
+
+# Copy installed packages from build stage
+COPY --from=build /usr/local/lib/python3.9/site-packages /usr/local/lib/python3.9/site-packages
+COPY --from=build /usr/local/bin /usr/local/bin
+
+# Copy application code
+COPY --from=build /app /app
+
+# Set permissions (optional)
+RUN chown -R myuser:myuser /app
+
+# Switch to non-root user
+USER myuser
+
+EXPOSE 9000
+
+# Run FastAPI app
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9000"]


### PR DESCRIPTION
I’ve added a Dockerfile to containerize the FastAPI application, as requested in issue #330. This should help with easier deployment and testing. Let me know if anything needs to be changed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/python-samples-fastapi-restful/340)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added a Dockerfile to enable containerized deployment of the FastAPI application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->