### PR TITLE
feat: add multi-stage Dockerfile for building and running app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1: Build
+FROM python:3.12-slim-bookworm AS build
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# Stage 2: Runtime
+FROM python:3.12-slim-bookworm AS runtime
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY models ./models
+COPY routes ./routes
+COPY schemas ./schemas
+COPY services ./services
+COPY data ./data
+COPY main.py .
+
+# Add non-root 'fastapi' user (optional for hardening)
+RUN adduser --disabled-password --gecos '' fastapi \
+    && chown -R fastapi:fastapi /app
+USER fastapi
+
+EXPOSE 9000
+ENV PYTHONUNBUFFERED=1
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,0 +1,16 @@
+// .commitlint.config.mjs
+import conventional from '@commitlint/config-conventional';
+
+export default {
+    ...conventional,
+    rules: {
+        'header-max-length': [2, 'always', 80],
+        'body-max-line-length': [2, 'always', 80],
+    },
+    ignores: [
+        // skip any commit whose body contains the Dependabot signature
+        (message) => message.includes('Signed‑off‑by: dependabot[bot]'),
+        // skip any Dependabot‑style bump header
+        (message) => /^chore\(deps(-dev)?\): bump /.test(message),
+    ],
+};


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/python-samples-fastapi-restful/342)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a new multi-stage Dockerfile for building and running the FastAPI application with enhanced security and efficiency.
  - Added a commit message linting configuration to enforce consistent commit formatting while excluding automated Dependabot commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->