### PR TITLE
chore(config): remove stale assets/ folder references

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -128,7 +128,6 @@ reviews:
     - "!**/*.db"
     - "!**/*.db-shm"
     - "!**/*.db-wal"
-    - "!**/assets/**"
     - "!**/postman_collections/**"
     - "!**/uv.lock"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,12 @@ This project uses famous football coaches as release codenames, following an A-Z
 - **BREAKING**: `DELETE /players/{player_id}` replaced by `DELETE /players/squadnumber/{squad_number}` — same rationale as above (#521)
 - `update_async` and `delete_async` (UUID-based) replaced by `update_by_squad_number_async` and `delete_by_squad_number_async` in `services/player_service.py` (#521)
 
+### Fixed
+
+- Removed stale `assets/` folder references from `Dockerfile`,
+  `codecov.yml`, and `.coderabbit.yaml` after the folder was deleted
+  when the README was migrated to Mermaid diagrams
+
 ---
 
 ## [1.1.0 - Bielsa] - 2026-03-02

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,6 @@ LABEL org.opencontainers.image.source="https://github.com/nanotaboada/python-sam
 
 # Copy metadata docs for container registries (e.g.: GitHub Container Registry)
 COPY README.md          ./
-COPY assets/            ./assets/
 
 # Copy pre-built wheels from builder
 COPY --from=builder     /app/wheelhouse/            /app/wheelhouse/

--- a/codecov.yml
+++ b/codecov.yml
@@ -39,7 +39,6 @@ comment:
 
 # https://docs.codecov.com/docs/ignoring-paths
 ignore:
-  - "^assets/.*"
   - "^databases/.*"
   - "^models/.*"
   - "^rest/.*"


### PR DESCRIPTION
## Summary

- Removes `COPY assets/ ./assets/` from `Dockerfile` — the folder was
  deleted when the README was migrated to Mermaid diagrams, causing the
  CD pipeline Docker build to fail
- Removes `^assets/.*` exclusion from `codecov.yml`
- Removes `!**/assets/**` exclusion from `.coderabbit.yaml`

## Root Cause

The `assets/` folder (containing `structure.svg` and `swagger.png`) was
deleted in a prior commit but references to it were left behind in three
configuration files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/python-samples-fastapi-restful/526)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed stale asset folder references from build, Docker, and code quality scanning configurations.

* **Documentation**
  * Updated changelog to document cleanup of obsolete asset folder references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->