### PR TITLE
feat(api): enforce squad number immutability on PUT

### DIFF
--- a/models/player_model.py
+++ b/models/player_model.py
@@ -5,6 +5,15 @@ Pydantic models defining the data schema for football players.
 - `PlayerRequestModel`: Represents player data for Create and Update operations.
 - `PlayerResponseModel`: Represents player data including UUID for Retrieve operations.
 
+Design decision — single request model vs split models:
+    A single `PlayerRequestModel` is intentionally shared by both POST (Create)
+    and PUT (Update). Per-operation differences are handled at the route layer
+    rather than by duplicating the model:
+    - POST checks that `squad_number` does not already exist (→ 409 Conflict).
+    - PUT checks that `squad_number` in the body matches the path parameter
+      (→ 400 Bad Request), ensuring the request is unambiguous. The path
+      parameter is always the authoritative source of identity on PUT.
+
 These models are used for data validation and serialization in the API.
 """
 

--- a/routes/player_route.py
+++ b/routes/player_route.py
@@ -199,9 +199,14 @@ async def put_async(
         async_session (AsyncSession): The async version of a SQLAlchemy ORM session.
 
     Raises:
+        HTTPException: HTTP 400 Bad Request if squad_number in the request body does
+        not match the path parameter. The path parameter is the authoritative source
+        of identity on PUT; a mismatch makes the request ambiguous.
         HTTPException: HTTP 404 Not Found error if the Player with the specified Squad
         Number does not exist.
     """
+    if player_model.squad_number != squad_number:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST)
     player = await player_service.retrieve_by_squad_number_async(
         async_session, squad_number
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -234,6 +234,20 @@ def test_request_put_player_squadnumber_existing_response_status_no_content(clie
     assert response.status_code == 204
 
 
+def test_request_put_player_squadnumber_mismatch_response_status_bad_request(client):
+    """PUT /players/squadnumber/{squad_number} with mismatched squad number in body returns 400 Bad Request"""
+    # Arrange
+    squad_number = existing_player().squad_number
+    player = existing_player()
+    player.squad_number = unknown_player().squad_number
+    # Act
+    response = client.put(
+        PATH + "squadnumber/" + str(squad_number), json=player.__dict__
+    )
+    # Assert
+    assert response.status_code == 400
+
+
 # DELETE /players/squadnumber/{squad_number} -----------------------------------
 
 


### PR DESCRIPTION
## Summary

- Add mismatch guard in `put_async`: if `squad_number` in the request body
  does not match the path parameter, return HTTP 400 Bad Request
- Document the single-model design decision in `PlayerRequestModel` module
  docstring, explaining why one model covers both POST and PUT
- Add test `test_request_put_player_squadnumber_mismatch_response_status_bad_request`

## Test plan

- [ ] `PUT /players/squadnumber/23` with body `squadNumber: 999` → 400 Bad Request
- [ ] `PUT /players/squadnumber/23` with body `squadNumber: 23` → 204 No Content
- [ ] `PUT /players/squadnumber/999` (unknown) with matching body → 404 Not Found
- [ ] `PUT /players/squadnumber/23` with empty body → 422 Unprocessable Entity
- [ ] All existing tests pass, coverage remains at 100%

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/python-samples-fastapi-restful/532)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the player update endpoint to validate that the squad number in the request body matches the squad number in the URL path, returning a 400 Bad Request if they differ for improved data consistency and clearer error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->