### PR TITLE
docs(changelog): release v2.1.0 Del Bosque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ This project uses famous football coaches as release codenames, following an A-Z
 
 ## [Unreleased]
 
+---
+
+## [2.1.0 - Del Bosque] - 2026-03-31
+
 ### Added
 
 - Architecture Decision Records (ADRs) in `docs/adr/` documenting key


### PR DESCRIPTION
Moves the `[Unreleased]` entries to `[2.1.0 - Del Bosque] - 2026-03-31`.

> **Note:** The `v2.1.0-delbosque` tag was pushed before this PR was merged.
> The CD pipeline ran successfully from the tagged commit. This PR exists solely
> to bring the CHANGELOG update back into `master`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/python-samples-fastapi-restful/547)
<!-- Reviewable:end -->
