### PR TITLE
docs(readme): normalize README structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Interactive API documentation is available via Swagger UI at `http://localhost:9
 | `DELETE` | `/players/squadnumber/{squad_number}` | Remove player by squad number | `204 No Content` |
 | `GET` | `/health` | Health check | `200 OK` |
 
-Error codes: `400 Bad Request` (validation failed) · `404 Not Found` (player not found) · `409 Conflict` (duplicate squad number on `POST`)
+Error codes: `400 Bad Request` (squad number mismatch on `PUT`) · `404 Not Found` (player not found) · `409 Conflict` (duplicate squad number on `POST`) · `422 Unprocessable Entity` (schema validation failed)
 
 For complete endpoint documentation with request/response schemas, explore the [interactive Swagger UI](http://localhost:9000/docs).
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -36,7 +36,7 @@ Before creating the tag, verify all of the following:
 - [ ] `CHANGELOG.md` `[Unreleased]` section is moved to a new versioned release entry
 - [ ] Release PR is merged into `master`
 - [ ] `uv run pytest` passes
-- [ ] Coach name is valid and follows alphabetical order (see [famous coach list](CHANGELOG.md))
+- [ ] Coach name is valid and follows alphabetical order (see "Release Naming Convention" in [CHANGELOG.md](CHANGELOG.md))
 - [ ] All CI checks on `master` are green
 
 ### 4. Create and Push Tag


### PR DESCRIPTION
Closes #556

## Summary

- Removed Table of Contents, Project Structure, Testing, Releases, and Architecture Decisions sections
- Features trimmed to 6 developer-facing bullets
- Architecture prose subsections replaced with 2-line callout + ADR one-liner
- API Reference converted to unified `Method | Endpoint | Description | Status` table
- Quick Start subheadings aligned with sibling repos (Clone / Install / Run / Access)
- Containers: added Docker pull block, removed redundant prose
- Contributing: absorbed testing instructions from removed Testing section; moved before Command Summary
- Command Summary: aligned column headers, removed verbose-only row, added AI Commands subsection
- New file: `RELEASES.md` — adds missing "Merge the Release PR" step (CD enforces reachable-from-master gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/python-samples-fastapi-restful/557)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Major README overhaul: concise, outcome-focused overview; removed TOC and deep architecture/test details; updated product description to a FastAPI + Python 3.13 layered CRUD "Players" service.
  * Streamlined Quick Start, reorganized Containers section, moved Contributing earlier, added an AI Commands summary, simplified API guidance with endpoint/status table and error codes.
  * Added RELEASES.md detailing standardized release naming, branch/tag workflow, and automated release/CD expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->