### PR TITLE
docs(changelog): release v2.1.1 Eriksson

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ This project uses famous football coaches as release codenames, following an A-Z
 
 ### Added
 
+### Changed
+
+### Fixed
+
+### Removed
+
+---
+
+## [2.1.1 - Eriksson] - 2026-04-11
+
+### Added
+
 - Extract `test` job from `release` in CD pipeline so tests run in isolation
   before any publish step; run `pytest -v` only (no coverage — CI owns that);
   add `enable-cache: true` to `astral-sh/setup-uv` for faster dependency
@@ -273,7 +285,9 @@ The CD workflow automatically:
 
 ---
 
-[unreleased]: https://github.com/nanotaboada/python-samples-fastapi-restful/compare/v2.0.0-capello...HEAD
+[unreleased]: https://github.com/nanotaboada/python-samples-fastapi-restful/compare/v2.1.1-eriksson...HEAD
+[2.1.1 - Eriksson]: https://github.com/nanotaboada/python-samples-fastapi-restful/compare/v2.1.0-delbosque...v2.1.1-eriksson
+[2.1.0 - Del Bosque]: https://github.com/nanotaboada/python-samples-fastapi-restful/compare/v2.0.0-capello...v2.1.0-delbosque
 [2.0.0 - Capello]: https://github.com/nanotaboada/python-samples-fastapi-restful/compare/v1.1.0-bielsa...v2.0.0-capello
 [1.1.0 - Bielsa]: https://github.com/nanotaboada/python-samples-fastapi-restful/compare/v1.0.0-ancelotti...v1.1.0-bielsa
 [1.0.0 - Ancelotti]: https://github.com/nanotaboada/python-samples-fastapi-restful/releases/tag/v1.0.0-ancelotti


### PR DESCRIPTION
## Summary

- Moves all `[Unreleased]` entries into `[2.1.1 - Eriksson] - 2026-04-11`
- Resets `[Unreleased]` to an empty template
- Updates compare links at the bottom of `CHANGELOG.md`

## Release

- **Tag**: `v2.1.1-eriksson`
- **Bump**: PATCH — no new API surface; all additions are infrastructure/tooling (Alembic, Gunicorn, CI/CD, Docker)

## Pre-commit checklist

- [x] `CHANGELOG.md` updated
- [x] `uv run flake8 .` — passed
- [x] `uv run black --check .` — passed (22 files unchanged)
- [x] `uv run pytest` — 25/25 passed
- [x] `uv run pytest --cov=./ --cov-report=term` — 98% coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/nanotaboada/python-samples-fastapi-restful/566)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated changelog with version 2.1.1 - Eriksson release (2026-04-11).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->